### PR TITLE
Make code Python3 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ SOURCE_GOLD = the source sentences with gold edits.
 ### Pre-requisites
 The following dependencies have to be installed to use the M^2 scorer.
 
-* Python (>= 2.6.4, < 3.0, older versions might work but are not tested)
+* Python (>= 2.6.4, <= 3.7, older and newer versions might work but are not tested)
 * nltk (http://www.nltk.org, needed for sentence splitting) 
 
 

--- a/scripts/Tokenizer.py
+++ b/scripts/Tokenizer.py
@@ -22,6 +22,7 @@
 # usage : %prog < input > output
 
 
+from __future__ import print_function
 import re
 import sys
 
@@ -174,4 +175,4 @@ if __name__ == "__main__":
         line = line.decode("utf8")
         tokens = tokenizer.tokenize(line.strip())
         out = ' '.join(tokens)
-        print out.encode("utf8")
+        print(out.encode("utf8"))

--- a/scripts/combiner.py
+++ b/scripts/combiner.py
@@ -29,6 +29,7 @@
 #   --ignore_whitespace_casing  -  Ignore edits that only affect whitespace and caseing. Default no."
 #
 
+from __future__ import print_function
 import sys
 import levenshtein
 from getopt import getopt
@@ -40,7 +41,7 @@ from util import smart_open
 def load_annotation(gold_file):
     source_sentences = []
     gold_edits = []
-    fgold = smart_open(gold_file, 'r')
+    fgold = smart_open(gold_file)
     puffer = fgold.read()
     fgold.close()
     puffer = puffer.decode('utf8')
@@ -73,7 +74,7 @@ def load_annotation(gold_file):
             tok_offset += len(this_sentence.split())
             source_sentences.append(this_sentence)
             this_edits = {}
-            for annotator, annotation in annotations.iteritems():
+            for annotator, annotation in annotations.items():
                 this_edits[annotator] = [edit for edit in annotation if edit[0] <= tok_offset and edit[1] <= tok_offset and edit[0] >= 0 and edit[1] >= 0]
             if len(this_edits) == 0:
                 this_edits[0] = []
@@ -82,15 +83,15 @@ def load_annotation(gold_file):
 
 
 def print_usage():
-    print >> sys.stderr, "Usage: m2scorer.py [OPTIONS] proposed_sentences gold_source"
-    print >> sys.stderr, "where"
-    print >> sys.stderr, "  proposed_sentences   -   system output, sentence per line"
-    print >> sys.stderr, "  source_gold          -   source sentences with gold token edits"
-    print >> sys.stderr, "OPTIONS"
-    print >> sys.stderr, "  -v    --verbose                   -  print verbose output"
-    print >> sys.stderr, "        --very_verbose              -  print lots of verbose output"
-    print >> sys.stderr, "        --max_unchanged_words N     -  Maximum unchanged words when extraction edit. Default 2."
-    print >> sys.stderr, "        --ignore_whitespace_casing  -  Ignore edits that only affect whitespace and caseing. Default no."
+    print("Usage: m2scorer.py [OPTIONS] proposed_sentences gold_source", file=sys.stderr)
+    print("where", file=sys.stderr)
+    print("  proposed_sentences   -   system output, sentence per line", file=sys.stderr)
+    print("  source_gold          -   source sentences with gold token edits", file=sys.stderr)
+    print("OPTIONS", file=sys.stderr)
+    print("  -v    --verbose                   -  print verbose output", file=sys.stderr)
+    print("        --very_verbose              -  print lots of verbose output", file=sys.stderr)
+    print("        --max_unchanged_words N     -  Maximum unchanged words when extraction edit. Default 2.", file=sys.stderr)
+    print("        --ignore_whitespace_casing  -  Ignore edits that only affect whitespace and caseing. Default no.", file=sys.stderr)
 
 
 
@@ -109,7 +110,7 @@ for o, v in opts:
     elif o == '--ignore_whitespace_casing':
         ignore_whitespace_casing = True
     else:
-        print >> sys.stderr, "Unknown option :", o
+        print("Unknown option :", o, file=sys.stderr)
         print_usage()
         sys.exit(-1)
 

--- a/scripts/edit_creator.py
+++ b/scripts/edit_creator.py
@@ -1,26 +1,27 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 import levenshtein
 from getopt import getopt
 from util import paragraphs
-from util import smart_open
 from levenshtein import equals_ignore_whitespace_casing
 from levenshtein import levenshtein_matrix, edit_graph, merge_graph, transitive_arcs
 import levenshtein
-from itertools import izip
-def print_usage():
-    print >> sys.stderr, "Usage: m2scorer.py [OPTIONS] source target"
-    print >> sys.stderr, "where"
-    print >> sys.stderr, "  source          -   the source input"
-    print >> sys.stderr, "  target          -   the target side of a parallel corpus or a system output"
 
-    print >> sys.stderr, "OPTIONS"
-    print >> sys.stderr, "  -v    --verbose                   	-  print verbose output"
-    print >> sys.stderr, "        --very_verbose              	-  print lots of verbose output"
-    print >> sys.stderr, "        --max_unchanged_words N     	-  Maximum unchanged words when extraction edit. Default 0."
-    print >> sys.stderr, "        --ignore_whitespace_casing  	-  Ignore edits that only affect whitespace and caseing. Default no."
-    print >> sys.stderr, "        --output  	                  -  The output file. Otherwise, it prints to standard output "
+
+def print_usage():
+    print("Usage: m2scorer.py [OPTIONS] source target", file=sys.stderr)
+    print("where", file=sys.stderr)
+    print("  source          -   the source input", file=sys.stderr)
+    print("  target          -   the target side of a parallel corpus or a system output", file=sys.stderr)
+
+    print("OPTIONS", file=sys.stderr)
+    print("  -v    --verbose                   	-  print verbose output", file=sys.stderr)
+    print("        --very_verbose              	-  print lots of verbose output", file=sys.stderr)
+    print("        --max_unchanged_words N     	-  Maximum unchanged words when extraction edit. Default 0.", file=sys.stderr)
+    print("        --ignore_whitespace_casing  	-  Ignore edits that only affect whitespace and caseing. Default no.", file=sys.stderr)
+    print("        --output  	                  -  The output file. Otherwise, it prints to standard output ", file=sys.stderr)
 
 
 max_unchanged_words=0
@@ -45,7 +46,7 @@ for o, v in opts:
     elif o == '--output':
         output = v
     else:
-        print >> sys.stderr, "Unknown option :", o
+        print("Unknown option :", o, file=sys.stderr)
         print_usage()
         sys.exit(-1)
 
@@ -66,10 +67,10 @@ system_read = open(target_file, 'r')
 source_read = open(source_file, 'r')
 
 count = 0
-print >> sys.stderr, "Process line by line: ",
-for candidate, source in izip(system_read, source_read):
+print("Process line by line: ", end=' ', file=sys.stderr)
+for candidate, source in zip(system_read, source_read):
     if not count % 1000:
-        print >> sys.stderr, count,
+        print(count, end=' ', file=sys.stderr)
     count += 1
     candidate = candidate.strip()
     source = source.strip()
@@ -89,16 +90,16 @@ for candidate, source in izip(system_read, source_read):
 
     # print the source sentence and target sentence
     # S = source, T = target
-    print >> write_output, "S {0}".format(source)
+    print("S {0}".format(source), file=write_output)
     if verbose:
-      print >> write_output, "T {0}".format(candidate)
+      print("T {0}".format(candidate), file=write_output)
 
     # Find the shortest path with an empty gold set
     gold = []
     localdist = levenshtein.set_weights(E, dist, edits, gold, verbose, very_verbose)
     editSeq = levenshtein.best_edit_seq_bf(V, E, localdist, edits, very_verbose)
     if ignore_whitespace_casing:
-        editSeq = filter(lambda x : not equals_ignore_whitespace_casing(x[2], x[3]), editSeq)
+        editSeq = [x for x in editSeq if not equals_ignore_whitespace_casing(x[2], x[3])]
 
     for ed in list(reversed(editSeq)):
         # Only print those "changed" edits
@@ -106,10 +107,10 @@ for candidate, source in izip(system_read, source_read):
             # Print the edits using format: A start end|||origin|||target|||anno_ID
             # At the moment, the annotation ID is always 0
             # print "A {0} {1}|||{2}|||{3}|||{4}".format(ed[0], ed[1], ed[2], ed[3], 0)
-            print >> write_output, "A {0} {1}|||{2}|||{3}|||{4}|||{5}|||{6}".format(ed[0], ed[1], "UNK", ed[3], 'REQUIRED', '-NONE-', 0)
-    print >> write_output,""
+            print("A {0} {1}|||{2}|||{3}|||{4}|||{5}|||{6}".format(ed[0], ed[1], "UNK", ed[3], 'REQUIRED', '-NONE-', 0), file=write_output)
+    print("", file=write_output)
 system_read.close()
 source_read.close()
-print >> sys.stderr, "Done!"
+print("Done!", file=sys.stderr)
 if output:
   write_output.close()

--- a/scripts/levenshtein.py
+++ b/scripts/levenshtein.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This file is part of the NUS M2 scorer.
 # The NUS M2 scorer is free software: you can redistribute it and/or modify
@@ -16,12 +16,15 @@
 
 # file: levenshtein.py
 
+from __future__ import print_function
+
 from optparse import OptionParser
-from itertools import izip
+
 from util import uniq
 import re
 import sys
 from copy import deepcopy
+
 
 # batch evaluation of a list of sentences
 def batch_precision(candidates, sources, gold_edits, max_unchanged_words=2, beta=0.5, ignore_whitespace_casing=False, verbose=False):
@@ -68,35 +71,35 @@ def f1_suffstats(candidate, source, gold_edits, max_unchanged_words=2, ignore_wh
     lmatrix, backpointers = levenshtein_matrix(source_tok, candidate_tok)
     V, E, dist, edits = edit_graph(lmatrix, backpointers)
     if very_verbose:
-        print "edit matrix:", lmatrix
-        print "backpointers:", backpointers
-        print "edits (w/o transitive arcs):", edits
+        print("edit matrix:", lmatrix)
+        print("backpointers:", backpointers)
+        print("edits (w/o transitive arcs):", edits)
     V, E, dist, edits = transitive_arcs(V, E, dist, edits, max_unchanged_words, very_verbose)
     dist = set_weights(E, dist, edits, gold_edits, very_verbose)
     editSeq = best_edit_seq_bf(V, E, dist, edits, very_verbose)
     if very_verbose:
-        print "Graph(V,E) = "
-        print "V =", V
-        print "E =", E
-        print "edits (with transitive arcs):", edits
-        print "dist() =", dist
-        print "viterbi path =", editSeq
+        print("Graph(V,E) = ")
+        print("V =", V)
+        print("E =", E)
+        print("edits (with transitive arcs):", edits)
+        print("dist() =", dist)
+        print("viterbi path =", editSeq)
     if ignore_whitespace_casing:
-        editSeq = filter(lambda x : not equals_ignore_whitespace_casing(x[2], x[3]), editSeq)
+        editSeq = [x for x in editSeq if not equals_ignore_whitespace_casing(x[2], x[3])]
     correct = matchSeq(editSeq, gold_edits, ignore_whitespace_casing)
     stat_correct = len(correct)
     stat_proposed = len(editSeq)
     stat_gold = len(gold_edits)
     if verbose:
-        print "SOURCE        :", source.encode("utf8")
-        print "HYPOTHESIS    :", candidate.encode("utf8")
-        print "EDIT SEQ      :", list(reversed(editSeq))
-        print "GOLD EDITS    :", gold_edits
-        print "CORRECT EDITS :", correct
-        print "# correct     :", int(stat_correct)
-        print "# proposed    :", int(stat_proposed)
-        print "# gold        :", int(stat_gold)
-        print "-------------------------------------------"
+        print("SOURCE        :", source.encode("utf8"))
+        print("HYPOTHESIS    :", candidate.encode("utf8"))
+        print("EDIT SEQ      :", list(reversed(editSeq)))
+        print("GOLD EDITS    :", gold_edits)
+        print("CORRECT EDITS :", correct)
+        print("# correct     :", int(stat_correct))
+        print("# proposed    :", int(stat_proposed))
+        print("# gold        :", int(stat_gold))
+        print("-------------------------------------------")
     return (stat_correct, stat_proposed, stat_gold)
 
 def batch_multi_pre_rec_f1(candidates, sources, gold_edits, max_unchanged_words=2, beta=0.5, ignore_whitespace_casing= False, verbose=False, very_verbose=False):
@@ -120,11 +123,11 @@ def batch_multi_pre_rec_f1(candidates, sources, gold_edits, max_unchanged_words=
 
         V, E, dist, edits = merge_graph(V1, V2, E1, E2, dist1, dist2, edits1, edits2)
         if very_verbose:
-            print "edit matrix 1:", lmatrix1
-            print "edit matrix 2:", lmatrix2
-            print "backpointers 1:", backpointers1
-            print "backpointers 2:", backpointers2
-            print "edits (w/o transitive arcs):", edits
+            print("edit matrix 1:", lmatrix1)
+            print("edit matrix 2:", lmatrix2)
+            print("backpointers 1:", backpointers1)
+            print("backpointers 2:", backpointers2)
+            print("edits (w/o transitive arcs):", edits)
         V, E, dist, edits = transitive_arcs(V, E, dist, edits, max_unchanged_words, very_verbose)
 
         # Find measures maximizing current cumulative F1; local: curent annotator only
@@ -138,20 +141,20 @@ def batch_multi_pre_rec_f1(candidates, sources, gold_edits, max_unchanged_words=
         max_stat_correct = -1.0
         min_stat_proposed = float("inf")
         min_stat_gold = float("inf")
-        for annotator, gold in golds_set.iteritems():
+        for annotator, gold in golds_set.items():
             localdist = set_weights(E, dist, edits, gold, verbose, very_verbose)
             editSeq = best_edit_seq_bf(V, E, localdist, edits, very_verbose)
             if verbose:
-                print ">> Annotator:", annotator
+                print(">> Annotator:", annotator)
             if very_verbose:
-                print "Graph(V,E) = "
-                print "V =", V
-                print "E =", E
-                print "edits (with transitive arcs):", edits
-                print "dist() =", localdist
-                print "viterbi path =", editSeq
+                print("Graph(V,E) = ")
+                print("V =", V)
+                print("E =", E)
+                print("edits (with transitive arcs):", edits)
+                print("dist() =", localdist)
+                print("viterbi path =", editSeq)
             if ignore_whitespace_casing:
-                editSeq = filter(lambda x : not equals_ignore_whitespace_casing(x[2], x[3]), editSeq)
+                editSeq = [x for x in editSeq if not equals_ignore_whitespace_casing(x[2], x[3])]
             correct = matchSeq(editSeq, gold, ignore_whitespace_casing, verbose)
 
             # local cumulative counts, P, R and F1
@@ -175,21 +178,21 @@ def batch_multi_pre_rec_f1(candidates, sources, gold_edits, max_unchanged_words=
                 argmax_gold = len(gold)
 
             if verbose:
-                print "SOURCE        :", source.encode("utf8")
-                print "HYPOTHESIS    :", candidate.encode("utf8")
-                print "EDIT SEQ      :", [shrinkEdit(ed) for ed in list(reversed(editSeq))]
-                print "GOLD EDITS    :", gold
-                print "CORRECT EDITS :", correct
-                print "# correct     :", int(stat_correct_local)
-                print "# proposed    :", int(stat_proposed_local)
-                print "# gold        :", int(stat_gold_local)
-                print "precision     :", p_local
-                print "recall        :", r_local
-                print "f_%.1f         :" % beta, f1_local
-                print "-------------------------------------------"
+                print("SOURCE        :", source.encode("utf8"))
+                print("HYPOTHESIS    :", candidate.encode("utf8"))
+                print("EDIT SEQ      :", [shrinkEdit(ed) for ed in list(reversed(editSeq))])
+                print("GOLD EDITS    :", gold)
+                print("CORRECT EDITS :", correct)
+                print("# correct     :", int(stat_correct_local))
+                print("# proposed    :", int(stat_proposed_local))
+                print("# gold        :", int(stat_gold_local))
+                print("precision     :", p_local)
+                print("recall        :", r_local)
+                print("f_%.1f         :" % beta, f1_local)
+                print("-------------------------------------------")
         if verbose:
-            print ">> Chosen Annotator for line", i, ":", chosen_ann
-            print ""
+            print(">> Chosen Annotator for line", i, ":", chosen_ann)
+            print("")
         stat_correct += argmax_correct
         stat_proposed += argmax_proposed
         stat_gold += argmax_gold
@@ -208,12 +211,12 @@ def batch_multi_pre_rec_f1(candidates, sources, gold_edits, max_unchanged_words=
     except ZeroDivisionError:
         f1 = 0.0
     if verbose:
-        print "CORRECT EDITS  :", int(stat_correct)
-        print "PROPOSED EDITS :", int(stat_proposed)
-        print "GOLD EDITS     :", int(stat_gold)
-        print "P =", p
-        print "R =", r
-        print "F_%.1f =" % beta, f1
+        print("CORRECT EDITS  :", int(stat_correct))
+        print("PROPOSED EDITS :", int(stat_proposed))
+        print("GOLD EDITS     :", int(stat_gold))
+        print("P =", p)
+        print("R =", r)
+        print("F_%.1f =" % beta, f1)
     return (p, r, f1)
 
 
@@ -228,38 +231,38 @@ def batch_pre_rec_f1(candidates, sources, gold_edits, max_unchanged_words=2, bet
         lmatrix, backpointers = levenshtein_matrix(source_tok, candidate_tok)
         V, E, dist, edits = edit_graph(lmatrix, backpointers)
         if very_verbose:
-            print "edit matrix:", lmatrix
-            print "backpointers:", backpointers
-            print "edits (w/o transitive arcs):", edits
+            print("edit matrix:", lmatrix)
+            print("backpointers:", backpointers)
+            print("edits (w/o transitive arcs):", edits)
         V, E, dist, edits = transitive_arcs(V, E, dist, edits, max_unchanged_words, very_verbose)
         dist = set_weights(E, dist, edits, gold, verbose, very_verbose)
         editSeq = best_edit_seq_bf(V, E, dist, edits, very_verbose)
         if very_verbose:
-            print "Graph(V,E) = "
-            print "V =", V
-            print "E =", E
-            print "edits (with transitive arcs):", edits
-            print "dist() =", dist
-            print "viterbi path =", editSeq
+            print("Graph(V,E) = ")
+            print("V =", V)
+            print("E =", E)
+            print("edits (with transitive arcs):", edits)
+            print("dist() =", dist)
+            print("viterbi path =", editSeq)
         if ignore_whitespace_casing:
-            editSeq = filter(lambda x : not equals_ignore_whitespace_casing(x[2], x[3]), editSeq)
+            editSeq = [x for x in editSeq if not equals_ignore_whitespace_casing(x[2], x[3])]
         correct = matchSeq(editSeq, gold, ignore_whitespace_casing)
         stat_correct += len(correct)
         stat_proposed += len(editSeq)
         stat_gold += len(gold)
         if verbose:
-            print "SOURCE        :", source.encode("utf8")
-            print "HYPOTHESIS    :", candidate.encode("utf8")
-            print "EDIT SEQ      :", list(reversed(editSeq))
-            print "GOLD EDITS    :", gold
-            print "CORRECT EDITS :", correct
-            print "# correct     :", stat_correct
-            print "# proposed    :", stat_proposed
-            print "# gold        :", stat_gold
-            print "precision     :", comp_p(stat_correct, stat_proposed)
-            print "recall        :", comp_r(stat_correct, stat_gold)
-            print "f_%.1f          :" % beta, comp_f1(stat_correct, stat_proposed, stat_gold, beta)
-            print "-------------------------------------------"
+            print("SOURCE        :", source.encode("utf8"))
+            print("HYPOTHESIS    :", candidate.encode("utf8"))
+            print("EDIT SEQ      :", list(reversed(editSeq)))
+            print("GOLD EDITS    :", gold)
+            print("CORRECT EDITS :", correct)
+            print("# correct     :", stat_correct)
+            print("# proposed    :", stat_proposed)
+            print("# gold        :", stat_gold)
+            print("precision     :", comp_p(stat_correct, stat_proposed))
+            print("recall        :", comp_r(stat_correct, stat_gold))
+            print("f_%.1f          :" % beta, comp_f1(stat_correct, stat_proposed, stat_gold, beta))
+            print("-------------------------------------------")
 
     try:
         p  = stat_correct / stat_proposed
@@ -276,12 +279,12 @@ def batch_pre_rec_f1(candidates, sources, gold_edits, max_unchanged_words=2, bet
     except ZeroDivisionError:
         f1 = 0.0
     if verbose:
-        print "CORRECT EDITS  :", stat_correct
-        print "PROPOSED EDITS :", stat_proposed
-        print "GOLD EDITS     :", stat_gold
-        print "P =", p
-        print "R =", r
-        print "F_%.1f =" % beta, f1
+        print("CORRECT EDITS  :", stat_correct)
+        print("PROPOSED EDITS :", stat_proposed)
+        print("GOLD EDITS     :", stat_gold)
+        print("P =", p)
+        print("R =", r)
+        print("F_%.1f =" % beta, f1)
     return (p, r, f1)
 
 # precision, recall, F1
@@ -348,15 +351,15 @@ def matchSeq(editSeq, gold_edits, ignore_whitespace_casing= False, verbose=False
                     if e[0] < e[1] and len(e[3].strip()) == 0 and \
                         (len(nextEditList) > 0 or len(prevEditList) > 0):
                         if matchAdj:
-                            print "!", e
+                            print("!", e)
                         else:
-                            print "&", e
+                            print("&", e)
                     elif e[0] == e[1] and \
                         (len(nextEditList) > 0 or len(prevEditList) > 0):
                         if matchAdj:
-                            print "!", e
+                            print("!", e)
                         else:
-                            print "*", e
+                            print("*", e)
     return m
 
 def matchEdit(e, g, ignore_whitespace_casing= False):
@@ -388,7 +391,7 @@ def get_edits(candidate, source, gold_edits, max_unchanged_words=2, ignore_white
     dist = set_weights(E, dist, edits, gold_edits, verbose, very_verbose)
     editSeq = best_edit_seq_bf(V, E, dist, edits)
     if ignore_whitespace_casing:
-        editSeq = filter(lambda x : not equals_ignore_whitespace_casing(x[2], x[3]), editSeq)
+        editSeq = [x for x in editSeq if not equals_ignore_whitespace_casing(x[2], x[3])]
     correct = matchSeq(editSeq, gold_edits)
     return (correct, editSeq, gold_edits)
 
@@ -401,7 +404,7 @@ def pre_rec_f1(candidate, source, gold_edits, max_unchanged_words=2, beta=0.5, i
     dist = set_weights(E, dist, edits, gold_edits, verbose, very_verbose)
     editSeq = best_edit_seq_bf(V, E, dist, edits)
     if ignore_whitespace_casing:
-        editSeq = filter(lambda x : not equals_ignore_whitespace_casing(x[2], x[3]), editSeq)
+        editSeq = [x for x in editSeq if not equals_ignore_whitespace_casing(x[2], x[3])]
     correct = matchSeq(editSeq, gold_edits)
     try:
         p  = float(len(correct)) / len(editSeq)
@@ -417,14 +420,14 @@ def pre_rec_f1(candidate, source, gold_edits, max_unchanged_words=2, beta=0.5, i
     except ZeroDivisionError:
         f1 = 0.0
     if verbose:
-        print "Source:", source.encode("utf8")
-        print "Hypothesis:", candidate.encode("utf8")
-        print "edit seq", editSeq
-        print "gold edits", gold_edits
-        print "correct edits", correct
-        print "p =", p
-        print "r =", r
-        print "f_%.1f =" % beta, f1
+        print("Source:", source.encode("utf8"))
+        print("Hypothesis:", candidate.encode("utf8"))
+        print("edit seq", editSeq)
+        print("gold edits", gold_edits)
+        print("correct edits", correct)
+        print("p =", p)
+        print("r =", r)
+        print("f_%.1f =" % beta, f1)
     return (p, r, f1)
 
 # distance function
@@ -531,8 +534,8 @@ def get_next_edges(cur, E):
 def set_weights(E, dist, edits, gold_edits, verbose=False, very_verbose=False):
     EPSILON = 0.001
     if very_verbose:
-        print "set weights of edges()",
-        print "gold edits :", gold_edits
+        print("set weights of edges()", end=' ')
+        print("gold edits :", gold_edits)
 
     gold_set = deepcopy(gold_edits)
     retdist = deepcopy(dist)
@@ -571,14 +574,14 @@ def set_weights(E, dist, edits, gold_edits, verbose=False, very_verbose=False):
                 thisEdit = edits[edge]
                 # only check start offset, end offset, original string, corrections
                 if very_verbose:
-                    print "set weights of edge", edge
-                    print "edit  =", thisEdit
+                    print("set weights of edge", edge)
+                    print("edit  =", thisEdit)
 
                 cur_gold = []
                 if cur == lptr:
-                    cur_gold = range(g_lptr, g_rptr+1)
+                    cur_gold = list(range(g_lptr, g_rptr+1))
                 else:
-                    cur_gold = reversed(range(g_lptr, g_rptr+1))
+                    cur_gold = reversed(list(range(g_lptr, g_rptr+1)))
 
                 for i in cur_gold:
                     gold = G[k][i]
@@ -589,8 +592,8 @@ def set_weights(E, dist, edits, gold_edits, verbose=False, very_verbose=False):
                         hasGoldMatch = True
                         retdist[edge] = - len(E)
                         if very_verbose:
-                            print "matched gold edit :", gold
-                            print "set weight to :", retdist[edge]
+                            print("matched gold edit :", gold)
+                            print("set weight to :", retdist[edge])
                         if cur == lptr:
                             #g_lptr += 1 # why?
                             g_lptr = i + 1
@@ -628,8 +631,8 @@ def set_weights(E, dist, edits, gold_edits, verbose=False, very_verbose=False):
                 hasGoldMatch = False
                 thisEdit = edits[edge]
                 if very_verbose:
-                    print "set weights of edge", edge
-                    print "edit  =", thisEdit
+                    print("set weights of edge", edge)
+                    print("edit  =", thisEdit)
                 for gold in G[k]:
                     if thisEdit[1] == gold[0] and \
                         thisEdit[2] == gold[1] and \
@@ -638,8 +641,8 @@ def set_weights(E, dist, edits, gold_edits, verbose=False, very_verbose=False):
                         hasGoldMatch = True
                         retdist[edge] = - len(E)
                         if very_verbose:
-                            print "matched gold edit :", gold
-                            print "set weight to :", retdist[edge]
+                            print("matched gold edit :", gold)
+                            print("set weight to :", retdist[edge])
                         break
                 if not hasGoldMatch and thisEdit[0] != 'noop':
                     retdist[edge] += EPSILON
@@ -648,16 +651,16 @@ def set_weights(E, dist, edits, gold_edits, verbose=False, very_verbose=False):
 # add transitive arcs
 def transitive_arcs(V, E, dist, edits, max_unchanged_words=2, very_verbose=False):
     if very_verbose:
-        print "-- Add transitive arcs --"
+        print("-- Add transitive arcs --")
     for k in range(len(V)):
         vk = V[k]
         if very_verbose:
-            print "v _k :", vk
+            print("v _k :", vk)
 
         for i in range(len(V)):
             vi = V[i]
             if very_verbose:
-                print "v _i :", vi
+                print("v _i :", vi)
             try:
                 eik = edits[(vi, vk)]
             except KeyError:
@@ -665,7 +668,7 @@ def transitive_arcs(V, E, dist, edits, max_unchanged_words=2, very_verbose=False
             for j in range(len(V)):
                 vj = V[j]
                 if very_verbose:
-                    print "v _j :", vj
+                    print("v _j :", vj)
                 try:
                     ekj = edits[(vk, vj)]
                 except KeyError:
@@ -676,18 +679,18 @@ def transitive_arcs(V, E, dist, edits, max_unchanged_words=2, very_verbose=False
                     eij = merge_edits(eik, ekj)
                     if eij[-1] <= max_unchanged_words:
                         if very_verbose:
-                            print " add new arcs v_i -> v_j:", eij
+                            print(" add new arcs v_i -> v_j:", eij)
                         E.append((vi, vj))
                         dist[(vi, vj)] = dik + dkj
                         edits[(vi, vj)] = eij
     # remove noop transitive arcs
     if very_verbose:
-        print "-- Remove transitive noop arcs --"
+        print("-- Remove transitive noop arcs --")
     for edge in E:
         e = edits[edge]
         if e[0] == 'noop' and dist[edge] > 1:
             if very_verbose:
-                print " remove noop arc v_i -> vj:", edge
+                print(" remove noop arc v_i -> vj:", edge)
             E.remove(edge)
             dist[edge] = float('inf')
             del edits[edge]
@@ -783,22 +786,22 @@ def merge_graph(V1, V2, E1, E2, dist1, dist2, edits1, edits2):
 
     # distances
     dist = deepcopy(dist1)
-    for k in dist2.keys():
-        if k not in dist.keys():
+    for k in list(dist2.keys()):
+        if k not in list(dist.keys()):
             dist[k] = dist2[k]
         else:
             if dist[k] != dist2[k]:
-                print >> sys.stderr, "WARNING: merge_graph: distance does not match!"
+                print("WARNING: merge_graph: distance does not match!", file=sys.stderr)
                 dist[k] = min(dist[k], dist2[k])
 
     # edit contents
     edits = deepcopy(edits1)
-    for e in edits2.keys():
-        if e not in edits.keys():
+    for e in list(edits2.keys()):
+        if e not in list(edits.keys()):
             edits[e] = edits2[e]
         else:
             if edits[e] != edits2[e]:
-                print >> sys.stderr, "WARNING: merge_graph: edit does not match!"
+                print("WARNING: merge_graph: edit does not match!", file=sys.stderr)
     return (V, E, dist, edits)
 
 # convenience method for levenshtein distance
@@ -829,7 +832,7 @@ def levenshtein_matrix(first, second, cost_ins=1, cost_del=1, cost_sub=2):
         backpointers[(0, j)] = [((0,j-1), edit)]
 
     # fill the matrix
-    for i in xrange(1, first_length):
+    for i in range(1, first_length):
         for j in range(1, second_length):
             deletion = distance_matrix[i-1][j] + cost_del
             insertion = distance_matrix[i][j-1] + cost_ins

--- a/scripts/m2scorer.py
+++ b/scripts/m2scorer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This file is part of the NUS M2 scorer.
 # The NUS M2 scorer is free software: you can redistribute it and/or modify
@@ -30,6 +30,7 @@
 #   --ignore_whitespace_casing  -  Ignore edits that only affect whitespace and caseing. Default no."
 #
 
+from __future__ import print_function
 import sys
 import levenshtein
 from getopt import getopt
@@ -37,11 +38,10 @@ from util import paragraphs
 from util import smart_open
 
 
-
 def load_annotation(gold_file):
     source_sentences = []
     gold_edits = []
-    fgold = smart_open(gold_file, 'r')
+    fgold = smart_open(gold_file)
     puffer = fgold.read()
     fgold.close()
     puffer = puffer.decode('utf8')
@@ -66,7 +66,7 @@ def load_annotation(gold_file):
             # NOTE: start and end are *token* offsets
             original = ' '.join(' '.join(sentence).split()[start_offset:end_offset])
             annotator = int(fields[5])
-            if annotator not in annotations.keys():
+            if annotator not in list(annotations.keys()):
                 annotations[annotator] = []
             annotations[annotator].append((start_offset, end_offset, original, corrections))
         tok_offset = 0
@@ -74,7 +74,7 @@ def load_annotation(gold_file):
             tok_offset += len(this_sentence.split())
             source_sentences.append(this_sentence)
             this_edits = {}
-            for annotator, annotation in annotations.iteritems():
+            for annotator, annotation in annotations.items():
                 this_edits[annotator] = [edit for edit in annotation if edit[0] <= tok_offset and edit[1] <= tok_offset and edit[0] >= 0 and edit[1] >= 0]
             if len(this_edits) == 0:
                 this_edits[0] = []
@@ -83,16 +83,16 @@ def load_annotation(gold_file):
 
 
 def print_usage():
-    print >> sys.stderr, "Usage: m2scorer.py [OPTIONS] proposed_sentences gold_source"
-    print >> sys.stderr, "where"
-    print >> sys.stderr, "  proposed_sentences   -   system output, sentence per line"
-    print >> sys.stderr, "  source_gold          -   source sentences with gold token edits"
-    print >> sys.stderr, "OPTIONS"
-    print >> sys.stderr, "  -v    --verbose                   -  print verbose output"
-    print >> sys.stderr, "        --very_verbose              -  print lots of verbose output"
-    print >> sys.stderr, "        --max_unchanged_words N     -  Maximum unchanged words when extraction edit. Default 2."
-    print >> sys.stderr, "        --beta B                    -  Beta value for F-measure. Default 0.5."
-    print >> sys.stderr, "        --ignore_whitespace_casing  -  Ignore edits that only affect whitespace and caseing. Default no."
+    print("Usage: m2scorer.py [OPTIONS] proposed_sentences gold_source", file=sys.stderr)
+    print("where", file=sys.stderr)
+    print("  proposed_sentences   -   system output, sentence per line", file=sys.stderr)
+    print("  source_gold          -   source sentences with gold token edits", file=sys.stderr)
+    print("OPTIONS", file=sys.stderr)
+    print("  -v    --verbose                   -  print verbose output", file=sys.stderr)
+    print("        --very_verbose              -  print lots of verbose output", file=sys.stderr)
+    print("        --max_unchanged_words N     -  Maximum unchanged words when extraction edit. Default 2.", file=sys.stderr)
+    print("        --beta B                    -  Beta value for F-measure. Default 0.5.", file=sys.stderr)
+    print("        --ignore_whitespace_casing  -  Ignore edits that only affect whitespace and caseing. Default no.", file=sys.stderr)
 
 
 
@@ -114,7 +114,7 @@ for o, v in opts:
     elif o == '--ignore_whitespace_casing':
         ignore_whitespace_casing = True
     else:
-        print >> sys.stderr, "Unknown option :", o
+        print("Unknown option :", o, file=sys.stderr)
         print_usage()
         sys.exit(-1)
 
@@ -130,13 +130,13 @@ gold_file = args[1]
 source_sentences, gold_edits = load_annotation(gold_file)
 
 # load system hypotheses
-fin = smart_open(system_file, 'r')
+fin = smart_open(system_file)
 system_sentences = [line.decode("utf8").strip() for line in fin.readlines()]
 fin.close()
 
 p, r, f1 = levenshtein.batch_multi_pre_rec_f1(system_sentences, source_sentences, gold_edits, max_unchanged_words, beta, ignore_whitespace_casing, verbose, very_verbose)
 
-print "Precision   : %.4f" % p
-print "Recall      : %.4f" % r
-print "F_%.1f       : %.4f" % (beta, f1)
+print("Precision   : %.4f" % p)
+print("Recall      : %.4f" % r)
+print("F_%.1f       : %.4f" % (beta, f1))
 

--- a/scripts/token_offsets.py
+++ b/scripts/token_offsets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # This file is part of the NUS M2 scorer.
 # The NUS M2 scorer is free software: you can redistribute it and/or modify
@@ -21,6 +21,7 @@
 #
 
 
+from __future__ import print_function
 import sys
 import re
 import os
@@ -40,7 +41,7 @@ for line in sys.stdin:
     if line.startswith("S "):
         sentence = line[2:]
         sentence_tok = "S " + ' '.join(tokenizer.tokenize(sentence))
-        print sentence_tok.encode("utf8")
+        print(sentence_tok.encode("utf8"))
     elif line.startswith("A "):
         fields = line[2:].split('|||')
         start_end = fields[0]
@@ -56,7 +57,7 @@ for line in sys.stdin:
         corrections = [(' '.join(tokenizer.tokenize(c))).strip() for c in fields[2].split('||')]
         fields[2] = '||'.join(corrections)
         annotation =  "A " + '|||'.join(fields)
-        print annotation.encode("utf8")
+        print(annotation.encode("utf8"))
     else:
-        print line.encode("utf8")
+        print(line.encode("utf8"))
 

--- a/scripts/util.py
+++ b/scripts/util.py
@@ -20,7 +20,7 @@ import random
 import math
 import re
 
-def smart_open(fname, mode = 'r'):
+def smart_open(fname, mode = 'rb'):
     if fname.endswith('.gz'):
         import gzip
         # Using max compression (9) by default seems to be slow.                                
@@ -52,7 +52,7 @@ def uniq(seq, idfun=None):
 
 def sort_dict(myDict, byValue=False, reverse=False):
     if byValue:
-        items = myDict.items()
+        items = list(myDict.items())
         items.sort(key = operator.itemgetter(1), reverse=reverse)
     else:
         items = sorted(myDict.items())
@@ -63,7 +63,7 @@ def max_dict(myDict, byValue=False):
         skey=lambda x:x[1]
     else:
         skey=lambda x:x[0]
-    return max(myDict.items(), key=skey)
+    return max(list(myDict.items()), key=skey)
 
 
 def min_dict(myDict, byValue=False):
@@ -71,7 +71,7 @@ def min_dict(myDict, byValue=False):
         skey=lambda x:x[1]
     else:
         skey=lambda x:x[0]
-    return min(myDict.items(), key=skey)
+    return min(list(myDict.items()), key=skey)
 
 def paragraphs(lines, is_separator=lambda x : x == '\n', joiner=''.join):
     paragraph = []
@@ -105,53 +105,53 @@ def intersect(x, y):
 # from http://effbot.org/zone/unicode-gremlins.htm
 cp1252 = {
     # from http://www.microsoft.com/typography/unicode/1252.htm
-    u"\x80": u"\u20AC", # EURO SIGN
-    u"\x82": u"\u201A", # SINGLE LOW-9 QUOTATION MARK
-    u"\x83": u"\u0192", # LATIN SMALL LETTER F WITH HOOK
-    u"\x84": u"\u201E", # DOUBLE LOW-9 QUOTATION MARK
-    u"\x85": u"\u2026", # HORIZONTAL ELLIPSIS
-    u"\x86": u"\u2020", # DAGGER
-    u"\x87": u"\u2021", # DOUBLE DAGGER
-    u"\x88": u"\u02C6", # MODIFIER LETTER CIRCUMFLEX ACCENT
-    u"\x89": u"\u2030", # PER MILLE SIGN
-    u"\x8A": u"\u0160", # LATIN CAPITAL LETTER S WITH CARON
-    u"\x8B": u"\u2039", # SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-    u"\x8C": u"\u0152", # LATIN CAPITAL LIGATURE OE
-    u"\x8E": u"\u017D", # LATIN CAPITAL LETTER Z WITH CARON
-    u"\x91": u"\u2018", # LEFT SINGLE QUOTATION MARK
-    u"\x92": u"\u2019", # RIGHT SINGLE QUOTATION MARK
-    u"\x93": u"\u201C", # LEFT DOUBLE QUOTATION MARK
-    u"\x94": u"\u201D", # RIGHT DOUBLE QUOTATION MARK
-    u"\x95": u"\u2022", # BULLET
-    u"\x96": u"\u2013", # EN DASH
-    u"\x97": u"\u2014", # EM DASH
-    u"\x98": u"\u02DC", # SMALL TILDE
-    u"\x99": u"\u2122", # TRADE MARK SIGN
-    u"\x9A": u"\u0161", # LATIN SMALL LETTER S WITH CARON
-    u"\x9B": u"\u203A", # SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-    u"\x9C": u"\u0153", # LATIN SMALL LIGATURE OE
-    u"\x9E": u"\u017E", # LATIN SMALL LETTER Z WITH CARON
-    u"\x9F": u"\u0178", # LATIN CAPITAL LETTER Y WITH DIAERESIS
+    "\x80": "\u20AC", # EURO SIGN
+    "\x82": "\u201A", # SINGLE LOW-9 QUOTATION MARK
+    "\x83": "\u0192", # LATIN SMALL LETTER F WITH HOOK
+    "\x84": "\u201E", # DOUBLE LOW-9 QUOTATION MARK
+    "\x85": "\u2026", # HORIZONTAL ELLIPSIS
+    "\x86": "\u2020", # DAGGER
+    "\x87": "\u2021", # DOUBLE DAGGER
+    "\x88": "\u02C6", # MODIFIER LETTER CIRCUMFLEX ACCENT
+    "\x89": "\u2030", # PER MILLE SIGN
+    "\x8A": "\u0160", # LATIN CAPITAL LETTER S WITH CARON
+    "\x8B": "\u2039", # SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+    "\x8C": "\u0152", # LATIN CAPITAL LIGATURE OE
+    "\x8E": "\u017D", # LATIN CAPITAL LETTER Z WITH CARON
+    "\x91": "\u2018", # LEFT SINGLE QUOTATION MARK
+    "\x92": "\u2019", # RIGHT SINGLE QUOTATION MARK
+    "\x93": "\u201C", # LEFT DOUBLE QUOTATION MARK
+    "\x94": "\u201D", # RIGHT DOUBLE QUOTATION MARK
+    "\x95": "\u2022", # BULLET
+    "\x96": "\u2013", # EN DASH
+    "\x97": "\u2014", # EM DASH
+    "\x98": "\u02DC", # SMALL TILDE
+    "\x99": "\u2122", # TRADE MARK SIGN
+    "\x9A": "\u0161", # LATIN SMALL LETTER S WITH CARON
+    "\x9B": "\u203A", # SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+    "\x9C": "\u0153", # LATIN SMALL LIGATURE OE
+    "\x9E": "\u017E", # LATIN SMALL LETTER Z WITH CARON
+    "\x9F": "\u0178", # LATIN CAPITAL LETTER Y WITH DIAERESIS
 }
 
 def fix_cp1252codes(text):
     # map cp1252 gremlins to real unicode characters
-    if re.search(u"[\x80-\x9f]", text):
+    if re.search("[\x80-\x9f]", text):
         def fixup(m):
             s = m.group(0)
             return cp1252.get(s, s)
         if isinstance(text, type("")):
             # make sure we have a unicode string
-            text = unicode(text, "iso-8859-1")
-        text = re.sub(u"[\x80-\x9f]", fixup, text)
+            text = str(text, "iso-8859-1")
+        text = re.sub("[\x80-\x9f]", fixup, text)
     return text
 
 def clean_utf8(text):
-    return filter(lambda x : x > '\x1f' and x < '\x7f', text)
+    return [x for x in text if x > '\x1f' and x < '\x7f']
 
 def pairs(iterable, overlapping=False):
     iterator = iterable.__iter__()
-    token = iterator.next()
+    token = next(iterator)
     i = 0
     for lookahead in iterator:
         if overlapping or i % 2 == 0: 


### PR DESCRIPTION
This PR adds Python 3 support while maintaining Python 2 compatibility (#9).

Most changes are done by the `2to3` tool. In addition, I changed the shebang to a more universal one and made a few other edits to keep Python 2.